### PR TITLE
composer: declare binary

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,8 @@
         }
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "bin": [
+        "bin/addic7ed-php"
+    ]
 }

--- a/main.php
+++ b/main.php
@@ -5,7 +5,13 @@ if (php_sapi_name() != 'cli') {
     exit(0);
 }
 
-require_once __DIR__ . '/vendor/autoload.php';
+if (is_dir(__DIR__.'/vendor')) {
+    // for development
+    require_once __DIR__ . '/vendor/autoload.php';
+} else {
+    // for global installation in ~/.composer
+    require_once __DIR__ . '/../../autoload.php';
+}
 
 array_shift($argv); // take out the first param (script name)
 


### PR DESCRIPTION
Just a last tiny little update ;-)

With this change landed (and a version bump), one should now be able to run

```
composer global require alixba/addic7ed-subtitles
```

and get the addic7ed-php available in ~/.composer/vendor/bin, thus working "out of the box" assuming composer is setup and added to the PATH

more info here: https://getcomposer.org/doc/articles/vendor-binaries.md

again, thanks!
